### PR TITLE
Updates README with new raw file link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Make a directory called `callback_plugins` next to your playbook and put `profil
 
     mkdir callback_plugins
     cd callback_plugins
-    wget https://github.com/jlafon/ansible-profile/raw/master/callback_plugins/profile_tasks.py
+    wget https://raw.githubusercontent.com/jlafon/ansible-profile/master/callback_plugins/profile_tasks.py
 
 Now, run your playbook just as you normally would!
 


### PR DESCRIPTION
The RAW link schemes appear to have been changed on github, the https://github.com raw link leads to a redirect.  I don't know if `wget` follows redirects by default, but `curl` does not and leads to a 1 line HTML file being downloaded.
